### PR TITLE
google analytics set up

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,6 +22,34 @@ module.exports = {
       },
     },
     {
+      resolve: "gatsby-plugin-google-tagmanager",
+      options: {
+        id: "UA-470225-24",
+  
+        // Include GTM in development.
+        //
+        // Defaults to false meaning GTM will only be loaded in production.
+        includeInDevelopment: false,
+  
+        // datalayer to be set before GTM is loaded
+        // should be an object or a function that is executed in the browser
+        //
+        // Defaults to null
+        defaultDataLayer: { platform: "gatsby" },
+  
+        // Specify optional GTM environment details.
+        // gtmAuth: "YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_AUTH_STRING",
+        // gtmPreview: "YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_PREVIEW_NAME",
+        // dataLayerName: "YOUR_DATA_LAYER_NAME",
+  
+        // Name of the event that is triggered
+        // on every Gatsby route change.
+        //
+        // Defaults to gatsby-route-change
+        // routeChangeEventName: "YOUR_ROUTE_CHANGE_EVENT_NAME",
+      },
+    },
+    {
       resolve: `gatsby-plugin-manifest`,
       options: {
         name: `Rocketseat Gatsby Themes`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10339,6 +10339,14 @@
         "minimatch": "3.0.4"
       }
     },
+    "gatsby-plugin-google-tagmanager": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-google-tagmanager/-/gatsby-plugin-google-tagmanager-2.8.0.tgz",
+      "integrity": "sha512-Jw6gLNYqVarJqORZsPHhs2svCKwCxb9U9FxsvZgyfTiLigN3nG2s7aMZpuUdtS0IJAmxQYIMew4AkN0vJedQJw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "gatsby-plugin-manifest": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby": "^2.28.2",
     "gatsby-plugin-canonical-urls": "^2.3.12",
     "gatsby-plugin-google-analytics": "^2.3.15",
+    "gatsby-plugin-google-tagmanager": "^2.8.0",
     "gatsby-plugin-manifest": "^2.4.33",
     "gatsby-plugin-netlify": "^2.8.0",
     "gatsby-plugin-netlify-cms": "^4.7.0",


### PR DESCRIPTION
Google analytics is now configured. You may have to configure the below in Google analytics though. [Source](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-tagmanager/)

This plugin will fire a new event called gatsby-route-change (or as in the gatsby-config.js configured routeChangeEventName) whenever a route is changed in your Gatsby application. To record this in Google Tag Manager, we will need to add a trigger to the desired tag to listen for the event:

Visit the Google Tag Manager console and click on the workspace for your site.
Navigate to the desired tag using the ‘Tags’ tab of the menu on the right hand side.
Under “Triggering”, click the pencil icon, then the ”+” button to add a new trigger.
In the “Choose a trigger” window, click on the ”+” button again.
Choose the trigger type by clicking the pencil button and clicking “Custom event”. For event name, enter gatsby-route-change (or as in the gatsby-config.js configured routeChangeEventName).
This tag will now catch every route change in Gatsby, and you can add Google tag services as you wish to it.