### PR TITLE
Adding a workspace snippet for frontmatter

### DIFF
--- a/.vscode/vscode.snippets.code-snippets
+++ b/.vscode/vscode.snippets.code-snippets
@@ -1,0 +1,14 @@
+{
+	"Generate DevIQ Template": {
+		"prefix": "deviq-template",
+		"description": "Frontmatter for DevIQ page",
+		"body": [
+			"---",
+			"title: \"\"",
+			"date: \"$CURRENT_YEAR-$CURRENT_MONTH-$CURRENT_DATE\"",
+			"description: \"\"",
+			"featuredImage: \"./images/X.png\"",
+			"---",
+		],
+	}
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ gatsby develop
 
 This will build the site and watch the folder for changes, automatically updating as changes are detected.
 
+## Adding Frontmatter to a File
+
+This project has a .vscode folder checked in. There is a snippet within that folder to make it easier to insert the frontmatter into a new page.
+
+Within VS Code:
+
+1. Bring up the Command Palette.
+2. Search for **Snippets: Insert Snippet**
+3. In **Workspace Snippets**, select the snippet named `deviq-template`.
+
 ## Exporting Mermaid Diagrams to SVG
 
 You can use [mermaid-cli](https://github.com/mermaid-js/mermaid-cli) to convert Mermaid diagrams to SVG. **This is how we create Mermaid graphs with links.**


### PR DESCRIPTION
This adds a Visual Studio Code workspace snippet for adding frontmatter to a page.

- README has been updated with notes on how to use it