### PR TITLE
Add alias to fix duplicated participant

### DIFF
--- a/src/docs/domain-driven-design/anti-corruption-layer.md
+++ b/src/docs/domain-driven-design/anti-corruption-layer.md
@@ -43,6 +43,7 @@ sequenceDiagram
     deactivate ACL
     activate Adapter
     Adapter->>External System: Send Translated Request
+    deactivate Adapter
     activate External System
     External System->>Adapter: Send Response
     deactivate External System
@@ -52,6 +53,8 @@ sequenceDiagram
     activate ACL
     ACL->>Domain Model: Provide Translated Data
     deactivate ACL
+    activate Domain Model
+    deactivate Domain Model
 ```
 
 ## Design Patterns in the ACL

--- a/src/docs/domain-driven-design/anti-corruption-layer.md
+++ b/src/docs/domain-driven-design/anti-corruption-layer.md
@@ -32,7 +32,7 @@ Here is a sequence diagram that shows these steps and how the components interac
 ```mermaid
 sequenceDiagram
     participant Domain Model
-    participant Anti-Corruption Layer (ACL)
+    participant ACL as Anti-Corruption Layer (ACL)
     participant External System
     activate Domain Model
     Domain Model->>ACL: Request

--- a/src/docs/domain-driven-design/anti-corruption-layer.md
+++ b/src/docs/domain-driven-design/anti-corruption-layer.md
@@ -33,6 +33,7 @@ Here is a sequence diagram that shows these steps and how the components interac
 sequenceDiagram
     participant Domain Model
     participant ACL as Anti-Corruption Layer (ACL)
+    participant Adapter
     participant External System
     activate Domain Model
     Domain Model->>ACL: Request


### PR DESCRIPTION
- In [ACL page sequence diagram](https://deviq.com/domain-driven-design/anti-corruption-layer#how-the-acl-works), there are duplicated participants: `ACL` and `Anti-Corruption Layer (ACL)`.
  - To fix this, Add alias `ACL` for `Anti-Corruption Layer (ACL)`.
- Adjust the order of participants in the sequence diagram to fit flow.
- Sync diagram's participants activations with text.

---

**AS-IS**
![image](https://github.com/user-attachments/assets/e68256b5-9f8f-4203-ae66-fd2e15c86544)

**TO-BE**
![image](https://github.com/user-attachments/assets/2599f6a8-b3e3-4b47-8a93-7cea463120ca)
