### PR TITLE
Fixing hot reloading for Gatsby site

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,3 +13,7 @@ RUN npm install -g gatsby-cli --unsafe-perm=true --allow-root
 
 # Set `DEVCONTAINER` environment variable to help with orientation
 ENV DEVCONTAINER=true
+# Use this to enable polling when Docker is used
+ENV CHOKIDAR_USEPOLLING=true
+# This is also used for Hot Module Reloading with Gatsby
+ENV INTERNAL_STATUS_PORT=5001

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+  "appPort": [8000,9000],
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind",
   "workspaceFolder": "/workspace",
   "remoteUser": "node",
@@ -11,6 +12,6 @@
     "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
   ],
   "runArgs": ["--name","deviq_gatsby_devcontainer"],
-  "postCreateCommand": "sudo chown node ${containerWorkspaceFolder}/node_modules",
-  "postStartCommand": "sudo npm install --legacy-peer-deps && sudo npx playwright install-deps && npx playwright install"
+    "postCreateCommand": "sudo chown node ${containerWorkspaceFolder}/node_modules && sudo npm install --legacy-peer-deps && sudo npx playwright install-deps",
+  "postStartCommand": "npx playwright install && gatsby develop --host 0.0.0.0"
 }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ If you don't have Node, NPM, or Gatsby installed locally, don't panic! We have [
 
 The [Dockerfile](./.devcontainer/Dockerfile) starts with a Node image that we need for this repo. It also installs the Gatsby CLI tooling.
 
+Because of the way dev containers work, if you want to run `gatsby serve` or `gatsby develop` and access the site from outside the container, you will need to use `--host 0.0.0.0` with the command to make it accessible outside of the container. So:
+
+- If you prefer the build-and-serve cycle, use `gatsby serve --host 0.0.0.0`
+- If you prefer to use the hot reload features, then use `gatsby develop --host 0.0.0.0`
+
 ## Local Dependencies
 
 If you do want to run this locally and not within a dev container, you will want to have the following installed:


### PR DESCRIPTION
- Exposing ports 8000 and 9000 for `gatsby develop` and `gatsby serve` respectively
- Set `CHOKIDAR_USEPOLLING` to allow clients to poll for changes (used in hot reload)
- Set `INTERNAL_STATUS_PORT` for websockets to listen to for Gatsby's Hot Module Reload technology
- Update the README to refer to `--host 0.0.0.0` so that the client can talk to the container