### PR TITLE
Removing a second call to createPage - should only need 1

### DIFF
--- a/src/@rocketseat/gatsby-theme-docs-core/gatsby-node.js
+++ b/src/@rocketseat/gatsby-theme-docs-core/gatsby-node.js
@@ -59,11 +59,6 @@ exports.createPages = (
       return;
     }
 
-    createPage({
-      path: basePath,
-      component: homeTemplate,
-    });
-
     // Generate prev/next items based on sidebar.yml file
     const sidebar = result.data.sidebar.edges;
     const listOfItems = [];


### PR DESCRIPTION
In the build, we get a lot of warnings with pages already created. Here's a sample of that messaging:

```
11:43:20 AM: warning Non-deterministic routing danger: Attempting to create page: "/antipatterns/analysis-paralysis/", but page "/antipatterns/analysis-paralysis" already exists
11:43:20 AM: This could lead to non-deterministic routing behavior
11:43:20 AM: warning Non-deterministic routing danger: Attempting to create page: "/antipatterns/antipatterns-overview/", but page "/antipatterns/antipatterns-overview" already exists
11:43:20 AM: This could lead to non-deterministic routing behavior
11:43:20 AM: warning Non-deterministic routing danger: Attempting to create page: "/antipatterns/architecture-by-implication/", but page "/antipatterns/architecture-by-implication" already exists
```

## Changes

I noticed there were 2 calls to `createPage` in the `.createPages` chunk. I have removed one of those calls.

I also updated the reporter for Create Docs since the pages aren't created just yet. It is now a `reporter.info` with logging that the pages are gathered from GraphQL.