### PR TITLE
Adding more promotions to the DevIQ announcements banner

### DIFF
--- a/src/@rocketseat/gatsby-theme-docs/components/Announcement/values.js
+++ b/src/@rocketseat/gatsby-theme-docs/components/Announcement/values.js
@@ -16,17 +16,21 @@ const announcementValues = {
 	// 	link: 'https://deviq.com/',
 	// 	text: 'values Announcement',
 	// },
-	// antipatterns: {
-	// 	link: 'https://deviq.com/',
-	// 	text: 'antipatterns Announcement',
-	// },
-	// 'domain-driven-design': {
-	// 	link: 'https://deviq.com/',
-	// 	text: 'domain-driven-design Announcement',
-	// },
-	// 'design-patterns': {
-	// 	link: 'https://deviq.com/',
-	// 	text: 'design-patterns Announcement',
-	// },
+	antipatterns: {
+	 	link: 'https://www.youtube.com/playlist?list=PL9aiMUEQ7sc944-LmunwduqFL1tHSE2fE',
+	 	text: '👻 Make your codebase less haunted with better design patterns!',
+	},
+	'domain-driven-design': {
+	 	link: 'https://www.pluralsight.com/courses/fundamentals-domain-driven-design',
+	 	text: '🐶 Learn about the fundamentals of Domain-Driven Design with Julie Lerman and Steve @ardalis Smith!',
+	},
+	'design-patterns': {
+	 	link: 'https://www.youtube.com/playlist?list=PL9aiMUEQ7sc944-LmunwduqFL1tHSE2fE',
+	 	text: '▶️ Want to learn more about design patterns? Learn more from NimblePros on YouTube!',
+	},
+	'architecture': {
+			link: 'https://dometrain.com/author/steve-ardalis-smith/',
+			text: '⚙️ From ASP.NET Core to modular monoliths, learn more from Steve @ardalis Smith!',
+	}
 };
 export default announcementValues;


### PR DESCRIPTION
## Context

While looking at the social media adventures and updating the DevIQ feed, I noticed opportunities for more promotions in the DevIQ announcement banner.

## Changes

The following announcement values will be added:

**Antipatterns**: [👻 Make your codebase less haunted with better design patterns!](https://www.youtube.com/playlist?list=PL9aiMUEQ7sc944-LmunwduqFL1tHSE2fE)

**Domain-Driven Design**: [🐶 Learn about the fundamentals of Domain-Driven Design with Julie Lerman and Steve @ardalis Smith!](https://www.pluralsight.com/courses/fundamentals-domain-driven-design)

**Design Patterns**: [▶️ Want to learn more about design patterns? Learn more from NimblePros on YouTube!](https://www.youtube.com/playlist?list=PL9aiMUEQ7sc944-LmunwduqFL1tHSE2fE)

**Architecture**: [⚙️ From ASP.NET Core to modular monoliths, learn more from Steve @ardalis Smith!](https://dometrain.com/author/steve-ardalis-smith/)