### PR TITLE
Fixing syntax error in generic repository return type

### DIFF
--- a/src/docs/design-patterns/repository-pattern.md
+++ b/src/docs/design-patterns/repository-pattern.md
@@ -26,7 +26,7 @@ interface IRepository<T> where T : EntityBase
 {
     Task<T> GetByIdAsync(int id);
     Task<List<T>> ListAsync();
-    TaskList<T> ListAsync(Expression<Func<T, bool>> predicate);
+    Task<List<T>> ListAsync(Expression<Func<T, bool>> predicate);
     Task AddAsync(T entity);
     Task DeleteAsync(T entity);
     Task EditAsync(T entity);


### PR DESCRIPTION
Min-fix: The return type in IRepository interface:

Url repository pattern section [source](https://deviq.com/design-patterns/repository-pattern#generic-repository-interface):

Evidence:

<img width="391" height="170" alt="image" src="https://github.com/user-attachments/assets/d6c4fdd4-657b-407d-b9ce-4e11f925fa93" />


